### PR TITLE
Add gitignore for local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+npm-debug.log*
+.DS_Store
+
+# Logs
+logs
+*.log
+
+# Wrangler build output
+.wrangler
+
+# Local environment files
+.env
+.env.*
+


### PR DESCRIPTION
## Summary
- add a project .gitignore to exclude local artifacts such as node_modules, logs, and environment files

## Testing
- `npx vitest run --passWithNoTests`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d765c308c832b97c5bd0e751da80b)