### PR TITLE
Add model allowlist, config endpoint, and UI model picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,16 @@ The frontend is a simple HTML/CSS/JavaScript application that:
 
 ### Changing the Model
 
-To use a different AI model, update the `MODEL_ID` constant in `src/index.ts`. You can find available models in the [Cloudflare Workers AI documentation](https://developers.cloudflare.com/workers-ai/models/).
+To use a different AI model, update the `MODEL_ID` variable in `wrangler.jsonc` (or set it as a Worker environment variable). You can find available models in the [Cloudflare Workers AI documentation](https://developers.cloudflare.com/workers-ai/models/).
+
+To allow users to upgrade or switch models from the UI:
+
+1. Set a comma-separated allowlist in `MODEL_ALLOWLIST`, for example:
+   ```
+   MODEL_ALLOWLIST="@cf/meta/llama-3.3-70b-instruct-fp8-fast,@cf/meta/llama-3.1-70b-instruct"
+   ```
+2. Deploy the Worker. The UI will fetch `/api/config` and populate the model picker with the allowlisted models.
+3. Select the desired model in the UI before sending messages.
 
 ### Using AI Gateway
 

--- a/public/index.html
+++ b/public/index.html
@@ -87,6 +87,34 @@
         background-color: white;
       }
 
+      .chat-controls {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        border-top: 1px solid var(--border-color);
+        background-color: white;
+        font-size: 0.9rem;
+      }
+
+      .chat-controls label {
+        color: var(--text-light);
+      }
+
+      #model-select {
+        padding: 0.4rem 0.6rem;
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        background-color: white;
+        font-size: 0.9rem;
+      }
+
+      .model-status {
+        margin-left: auto;
+        color: var(--text-light);
+        font-size: 0.8rem;
+      }
+
       #user-input {
         flex: 1;
         padding: 0.75rem;
@@ -154,6 +182,12 @@
 
       <div class="typing-indicator" id="typing-indicator">
         AI is thinking...
+      </div>
+
+      <div class="chat-controls">
+        <label for="model-select">Model</label>
+        <select id="model-select" disabled></select>
+        <span class="model-status" id="model-status">Loading models…</span>
       </div>
 
       <div class="message-input">

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface Env {
    * Configuration variables
    */
   MODEL_ID?: string;
+  MODEL_ALLOWLIST?: string;
   SYSTEM_PROMPT?: string;
   MAX_MESSAGE_LENGTH?: string;
   MAX_MESSAGES?: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,6 +20,7 @@
   "upload_source_maps": true,
   "vars": {
     "MODEL_ID": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    "MODEL_ALLOWLIST": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
     "SYSTEM_PROMPT": "You are a helpful, friendly assistant. Provide concise and accurate responses.",
     "MAX_MESSAGE_LENGTH": "10000",
     "MAX_MESSAGES": "100",


### PR DESCRIPTION
### Motivation

- Provide a safe way to upgrade or switch LLM models at runtime by exposing an allowlist and enabling users to choose a model from the UI while preventing unauthorized model selection on the backend.

### Description

- Add `/api/config` endpoint and `parseModelAllowlist` helper to expose the default model and a parsed `MODEL_ALLOWLIST` for the UI in `src/index.ts`.
- Validate per-request model selection in `handleChatRequest`, choose the requested model if allowlisted, and fall back to the default model when absent in `src/index.ts`.
- Add `MODEL_ALLOWLIST` to the `Env` types and `wrangler.jsonc` vars, update `README.md` with the upgrade/switch workflow, and document how to set the allowlist.
- Wire a model picker into the frontend by adding UI controls in `public/index.html` and client logic in `public/chat.js` to fetch `/api/config`, populate the selector, and include the selected model in chat POST payloads.

### Testing

- Started the local dev server with `npm run dev` (wrangler dev) and the server reported readiness and environment bindings successfully. (Succeeded)
- Exercised the frontend by loading the app with a Playwright script that navigated to the local server and saved a screenshot of the UI (produced `artifacts/model-picker.png`). (Succeeded)
- Exercised HTTP endpoints during local run where requests to `/` and `/chat.js` and `GET /api/config` returned `200 OK`. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b113966cc832b9b5b62028f0c567a)