### PR TITLE
Add message timestamps and rename UI to Daddy Chatty

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -17,16 +17,19 @@ const MAX_MESSAGE_LENGTH = 10000; // Maximum characters per message
 const REQUEST_TIMEOUT = 60000; // Request timeout in milliseconds (60 seconds)
 
 // Chat state
+const initialAssistantMessage =
+  "Hi! I'm the daddy, powered by Cloudflare Workers AI. How can I help you today?";
+
 let chatHistory = [
   {
     role: "assistant",
-    content:
-      "Hello! I'm an LLM chat app powered by Cloudflare Workers AI. How can I help you today?",
+    content: initialAssistantMessage,
   },
 ];
 let isProcessing = false;
 
 loadModelConfig();
+addMessageToChat("assistant", initialAssistantMessage);
 
 // Auto-resize textarea as user types
 userInput.addEventListener("input", function () {
@@ -134,10 +137,8 @@ async function sendMessage() {
 
   try {
     // Create new assistant response element
-    const assistantMessageEl = document.createElement("div");
-    assistantMessageEl.className = "message assistant-message";
-    const assistantParagraph = document.createElement("p");
-    assistantMessageEl.appendChild(assistantParagraph);
+    const assistantMessageEl = createMessageElement("assistant", "");
+    const assistantParagraph = assistantMessageEl.querySelector("p");
     chatMessages.appendChild(assistantMessageEl);
 
     // Scroll to bottom
@@ -272,13 +273,37 @@ async function sendMessage() {
  * Helper function to add message to chat
  */
 function addMessageToChat(role, content) {
-  const messageEl = document.createElement("div");
-  messageEl.className = `message ${role}-message`;
-  const paragraph = document.createElement("p");
-  paragraph.textContent = content;
-  messageEl.appendChild(paragraph);
+  const messageEl = createMessageElement(role, content);
   chatMessages.appendChild(messageEl);
 
   // Scroll to bottom
   chatMessages.scrollTop = chatMessages.scrollHeight;
+}
+
+function createMessageElement(role, content) {
+  const messageEl = document.createElement("div");
+  messageEl.className = `message ${role}-message`;
+
+  const header = document.createElement("div");
+  header.className = "message-header";
+
+  const timestamp = document.createElement("span");
+  timestamp.className = "message-timestamp";
+  timestamp.textContent = formatTimestamp(new Date());
+
+  header.appendChild(timestamp);
+  messageEl.appendChild(header);
+
+  const paragraph = document.createElement("p");
+  paragraph.textContent = content;
+  messageEl.appendChild(paragraph);
+
+  return messageEl;
+}
+
+function formatTimestamp(date) {
+  return date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>LLM Chat App</title>
+    <title>Daddy Chatty</title>
     <style>
       :root {
         --primary-color: #f6821f;
@@ -67,6 +67,21 @@
         padding: 0.75rem;
         border-radius: 8px;
         max-width: 80%;
+      }
+
+      .message-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.5rem;
+        margin-bottom: 0.35rem;
+        font-size: 0.75rem;
+        color: var(--text-light);
+      }
+
+      .message-timestamp {
+        margin-left: auto;
+        white-space: nowrap;
       }
 
       .user-message {
@@ -166,19 +181,12 @@
   </head>
   <body>
     <header>
-      <h1>Cloudflare AI Chat</h1>
+      <h1>Daddy Chatty</h1>
       <p>Powered by Cloudflare Workers AI</p>
     </header>
 
     <div class="chat-container">
-      <div id="chat-messages" class="chat-messages">
-        <div class="message assistant-message">
-          <p>
-            Hello! I'm an LLM chat app powered by Cloudflare Workers AI. How can
-            I help you today?
-          </p>
-        </div>
-      </div>
+      <div id="chat-messages" class="chat-messages"></div>
 
       <div class="typing-indicator" id="typing-indicator">
         AI is thinking...


### PR DESCRIPTION
### Motivation
- Add visible timestamps to chat messages to show when messages were sent and improve readability.
- Change the default assistant greeting from a generic LLM string to the new copy `Hi! I'm the daddy` and update the app branding.
- Move the initial assistant message into the JS render flow so all messages use the same timestamped layout.

### Description
- Updated `public/index.html` to rename the app title/header to `Daddy Chatty`, remove the static starter message, and add CSS for `.message-header` and `.message-timestamp`.
- Updated `public/chat.js` to introduce `initialAssistantMessage`, render that message via `addMessageToChat`, and keep `chatHistory` consistent with the UI.
- Added `createMessageElement(role, content)` and `formatTimestamp(date)` helpers to construct message DOM nodes with a timestamp header for every message and replaced inline message creation with these helpers.
- Adjusted streaming response handling to create and append an assistant response element via `createMessageElement` and update its paragraph text as chunks arrive.

### Testing
- Launched a local static server with `python -m http.server 8000` to serve the frontend, which started successfully.
- Attempted an automated Playwright script to capture a screenshot of `public/index.html`, but the headless Chromium run failed with a native crash (Playwright `TargetClosedError` / SIGSEGV) so the screenshot did not complete.
- No unit or integration test suite was run during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b1326ea5c832b8e01ee6fdd80dd93)