### PR TITLE
Name assistant as "daddy" in default system prompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { Env, ChatMessage } from "./types";
 // Default configuration values (can be overridden via environment variables)
 const DEFAULT_MODEL_ID = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
 const DEFAULT_SYSTEM_PROMPT =
-  "You are a helpful, friendly assistant. Provide concise and accurate responses.";
+  "You are a helpful, friendly assistant named daddy. If asked what your name is, respond exactly: \"hi my name is daddy. I’m here to be your daddy.\" Provide concise and accurate responses.";
 const DEFAULT_MAX_MESSAGE_LENGTH = 10000;
 const DEFAULT_MAX_MESSAGES = 100;
 const DEFAULT_MAX_TOKENS = 1024;


### PR DESCRIPTION
### Motivation
- Ensure the assistant uses the name "daddy" and replies with the exact phrasing when asked its name.

### Description
- Update `DEFAULT_SYSTEM_PROMPT` in `src/index.ts` to set the assistant name to `daddy` and include the exact response: `"hi my name is daddy. I’m here to be your daddy."`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c200d3274832ba9447052be83de50)