### PR TITLE
Update default system prompt to enforce 'daddy' identity responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { Env, ChatMessage } from "./types";
 // Default configuration values (can be overridden via environment variables)
 const DEFAULT_MODEL_ID = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
 const DEFAULT_SYSTEM_PROMPT =
-  "You are a helpful, friendly assistant named daddy. If asked what your name is, respond exactly: \"hi my name is daddy. I’m here to be your daddy.\" Provide concise and accurate responses.";
+  "You are a helpful, friendly assistant named daddy. If asked who you are or what your name is, respond exactly: \"hi I’m your daddy. I’m here to help you as your daddy. How can daddy help you\". If asked again, respond exactly: \"I’m here to be a daddy and to help you.\" Provide concise and accurate responses.";
 const DEFAULT_MAX_MESSAGE_LENGTH = 10000;
 const DEFAULT_MAX_MESSAGES = 100;
 const DEFAULT_MAX_TOKENS = 1024;


### PR DESCRIPTION
### Motivation
- Ensure the assistant answers identity questions with the requested "daddy" phrasing instead of a generic AI identity by encoding the behavior in the system prompt.

### Description
- Replace the `DEFAULT_SYSTEM_PROMPT` in `src/index.ts` with a new prompt that instructs the assistant to respond exactly with `"hi I’m your daddy. I’m here to help you as your daddy. How can daddy help you"` for initial identity questions and `"I’m here to be a daddy and to help you."` on follow-up.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c236c0dd8832bba4d43f014738bde)