### PR TITLE
Fix TypeScript type errors in env config and tests

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -292,7 +292,7 @@ describe("handleChatRequest", () => {
     const response = await handleChatRequest(request, env);
 
     expect(response.status).toBe(413);
-    const json = await response.json();
+    const json = (await response.json()) as { error: string };
     expect(json.error).toContain("Request body too large");
     expect(runMock).not.toHaveBeenCalled();
   });
@@ -815,7 +815,7 @@ describe("parseJsonBodyWithLimit", () => {
     expect(result).toHaveProperty("error");
     if ("error" in result) {
       expect(result.error.status).toBe(413);
-      const json = await result.error.json();
+      const json = (await result.error.json()) as { error: string };
       expect(json.error).toContain("Request body too large");
     }
   });
@@ -831,7 +831,7 @@ describe("parseJsonBodyWithLimit", () => {
     expect(result).toHaveProperty("error");
     if ("error" in result) {
       expect(result.error.status).toBe(400);
-      const json = await result.error.json();
+      const json = (await result.error.json()) as { error: string };
       expect(json.error).toBe("Invalid JSON body");
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -484,7 +484,7 @@ export async function handleChatRequest(
       );
     }
 
-    const modelToUse = requestedModel || MODEL_ID;
+    const modelToUse = (requestedModel || MODEL_ID) as keyof AiModels;
     const normalizedClientContext = normalizeClientContext(clientContext);
     const contextualSystemPrompt = buildContextualSystemPrompt(
       SYSTEM_PROMPT,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface Env {
   MAX_MESSAGE_LENGTH?: string;
   MAX_MESSAGES?: string;
   MAX_TOKENS?: string;
+  MAX_BODY_BYTES?: string;
   RATE_LIMIT_REQUESTS?: string;
   RATE_LIMIT_WINDOW_MS?: string;
 }


### PR DESCRIPTION
### Motivation
- Resolve TypeScript build errors triggered by strict typings and test assertions to ensure `tsc` and the test suite pass.

### Description
- Add missing `MAX_BODY_BYTES?: string` to the `Env` interface in `src/types.ts` to expose the body-size config.
- Cast the validated model to `keyof AiModels` when calling `env.AI.run` in `src/index.ts` to satisfy the Workers AI types (`modelToUse` as `keyof AiModels`).
- Tighten test JSON typings in `src/index.test.ts` by casting `response.json()` results to `{ error: string }` where appropriate to satisfy strict TypeScript checks.

### Testing
- Ran the unit test suite with `npm test` (Vitest), all tests passed (`79` tests passed).
- Ran `npm run check` which executes `tsc --noEmit` and `wrangler deploy --dry-run`, and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c83f86394832ba6df52cdd1f4507b)