### PR TITLE
Refresh chat UI styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,14 +6,19 @@
     <title>test LLM</title>
     <style>
       :root {
-        --primary-color: #f6821f;
-        --primary-hover: #e67e22;
-        --light-bg: #f9fafb;
-        --border-color: #e5e7eb;
-        --text-color: #1f2937;
-        --text-light: #6b7280;
-        --user-msg-bg: #fff2e6;
-        --assistant-msg-bg: #f3f4f6;
+        --primary-color: #6d28d9;
+        --primary-hover: #5b21b6;
+        --accent-color: #22d3ee;
+        --light-bg: #f8fafc;
+        --border-color: #e2e8f0;
+        --text-color: #0f172a;
+        --text-light: #64748b;
+        --user-msg-bg: #eef2ff;
+        --assistant-msg-bg: #f1f5f9;
+        --surface: #ffffff;
+        --surface-muted: rgba(255, 255, 255, 0.75);
+        --shadow-color: rgba(15, 23, 42, 0.12);
+        --ring-color: rgba(109, 40, 217, 0.25);
       }
 
       * {
@@ -28,21 +33,56 @@
           Cantarell, sans-serif;
         line-height: 1.6;
         color: var(--text-color);
-        max-width: 800px;
+        min-height: 100vh;
+        background:
+          radial-gradient(circle at top left, rgba(109, 40, 217, 0.12), transparent 45%),
+          radial-gradient(circle at top right, rgba(34, 211, 238, 0.18), transparent 40%),
+          #f8fafc;
+        padding: 2rem 1.5rem 3rem;
+      }
+
+      .page {
+        max-width: 960px;
         margin: 0 auto;
-        padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
       }
 
       header {
         text-align: center;
-        margin-bottom: 2rem;
-        padding: 1rem 0;
-        border-bottom: 1px solid var(--border-color);
+        padding: 1.5rem;
+        border-radius: 20px;
+        background: var(--surface-muted);
+        border: 1px solid rgba(226, 232, 240, 0.8);
+        box-shadow: 0 20px 40px var(--shadow-color);
+        backdrop-filter: blur(18px);
       }
 
       h1 {
-        font-size: 1.5rem;
+        font-size: 1.9rem;
+        color: var(--text-color);
+        letter-spacing: -0.02em;
+      }
+
+      .subtitle {
+        margin-top: 0.4rem;
+        color: var(--text-light);
+      }
+
+      .tagline {
+        margin-top: 0.75rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.35rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(109, 40, 217, 0.12);
         color: var(--primary-color);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
       }
 
       .chat-container {
@@ -50,9 +90,11 @@
         flex-direction: column;
         height: calc(100vh - 200px);
         min-height: 400px;
-        border: 1px solid var(--border-color);
-        border-radius: 8px;
+        border-radius: 20px;
         overflow: hidden;
+        background: var(--surface);
+        border: 1px solid rgba(226, 232, 240, 0.9);
+        box-shadow: 0 24px 50px var(--shadow-color);
       }
 
       .chat-messages {
@@ -60,13 +102,21 @@
         overflow-y: auto;
         padding: 1rem;
         background-color: var(--light-bg);
+        background-image: linear-gradient(
+            180deg,
+            rgba(255, 255, 255, 0.9),
+            rgba(248, 250, 252, 0.8)
+          ),
+          radial-gradient(circle at top left, rgba(109, 40, 217, 0.08), transparent 35%),
+          radial-gradient(circle at bottom right, rgba(34, 211, 238, 0.12), transparent 40%);
       }
 
       .message {
         margin-bottom: 1rem;
-        padding: 0.75rem;
-        border-radius: 8px;
+        padding: 0.85rem 1rem;
+        border-radius: 14px;
         max-width: 80%;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.06);
       }
 
       .message-header {
@@ -99,7 +149,7 @@
         display: flex;
         padding: 0.75rem;
         border-top: 1px solid var(--border-color);
-        background-color: white;
+        background-color: var(--surface);
       }
 
       .chat-status {
@@ -109,7 +159,7 @@
         gap: 0.75rem;
         padding: 0.5rem 0.75rem 0;
         border-top: 1px solid var(--border-color);
-        background-color: white;
+        background-color: var(--surface);
         font-size: 0.9rem;
       }
 
@@ -125,24 +175,34 @@
         padding: 0.2rem 0.55rem;
         border-radius: 999px;
         border: 1px solid var(--border-color);
-        background: white;
+        background: var(--surface);
         transition: all 0.2s ease;
       }
 
       .presence-status.active {
         color: var(--primary-color);
-        border-color: rgba(246, 130, 31, 0.4);
-        box-shadow: 0 0 12px rgba(246, 130, 31, 0.25);
+        border-color: rgba(109, 40, 217, 0.35);
+        box-shadow: 0 0 18px rgba(109, 40, 217, 0.2);
+        background: rgba(109, 40, 217, 0.1);
       }
 
       #user-input {
         flex: 1;
         padding: 0.75rem;
         border: 1px solid var(--border-color);
-        border-radius: 4px;
+        border-radius: 12px;
         font-family: inherit;
         resize: none;
         min-height: 44px;
+        background: var(--light-bg);
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      #user-input:focus {
+        outline: none;
+        border-color: var(--primary-color);
+        box-shadow: 0 0 0 4px var(--ring-color);
+        background: var(--surface);
       }
 
       #send-button {
@@ -152,14 +212,14 @@
         gap: 0.45rem;
         padding: 0 1.1rem;
         min-height: 44px;
-        background: linear-gradient(135deg, #f6821f 0%, #ffb347 100%);
+        background: linear-gradient(135deg, #6d28d9 0%, #22d3ee 100%);
         color: white;
         border: none;
-        border-radius: 4px;
+        border-radius: 12px;
         cursor: pointer;
         font-weight: 600;
         letter-spacing: 0.01em;
-        box-shadow: 0 10px 20px rgba(246, 130, 31, 0.2);
+        box-shadow: 0 12px 24px rgba(109, 40, 217, 0.25);
         position: relative;
         overflow: hidden;
         transition:
@@ -169,7 +229,7 @@
 
       #send-button:hover {
         transform: translateY(-1px);
-        box-shadow: 0 14px 24px rgba(246, 130, 31, 0.35);
+        box-shadow: 0 18px 30px rgba(109, 40, 217, 0.3);
       }
 
       #send-button:disabled {
@@ -199,7 +259,7 @@
 
       #send-button.is-sending {
         transform: translateY(0);
-        box-shadow: 0 0 20px rgba(246, 130, 31, 0.35);
+        box-shadow: 0 0 24px rgba(34, 211, 238, 0.35);
       }
 
       .send-icon {
@@ -228,7 +288,6 @@
       }
 
       footer {
-        margin-top: 1rem;
         text-align: center;
         font-size: 0.85rem;
         color: var(--text-light);
@@ -236,46 +295,49 @@
     </style>
   </head>
   <body>
-    <header>
-      <h1>test LLM</h1>
-      <p>Powered by Cloudflare Workers AI</p>
-    </header>
+    <div class="page">
+      <header>
+        <h1>test LLM</h1>
+        <p class="subtitle">A fresh chat experience powered by Cloudflare Workers AI</p>
+        <span class="tagline">Realtime chat</span>
+      </header>
 
-    <div class="chat-container">
-      <div id="chat-messages" class="chat-messages"></div>
+      <div class="chat-container">
+        <div id="chat-messages" class="chat-messages"></div>
 
-      <div class="typing-indicator" id="typing-indicator">
-        AI is thinking...
+        <div class="typing-indicator" id="typing-indicator">
+          AI is thinking...
+        </div>
+
+        <div class="chat-status">
+          <span class="context-status" id="context-status"></span>
+          <span class="presence-status" id="presence-status">Ready</span>
+        </div>
+
+        <div class="message-input">
+          <textarea
+            id="user-input"
+            placeholder="Type your message here..."
+            rows="1"
+            autofocus
+          ></textarea>
+          <button id="send-button" type="button">
+            <span class="send-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+                <path
+                  d="M3.4 20.6 22 12 3.4 3.4l-.8 6.2L14 12 2.6 14.4l.8 6.2z"
+                />
+              </svg>
+            </span>
+            <span class="send-label">Send</span>
+          </button>
+        </div>
       </div>
 
-      <div class="chat-status">
-        <span class="context-status" id="context-status"></span>
-        <span class="presence-status" id="presence-status">Ready</span>
-      </div>
-
-      <div class="message-input">
-        <textarea
-          id="user-input"
-          placeholder="Type your message here..."
-          rows="1"
-          autofocus
-        ></textarea>
-        <button id="send-button" type="button">
-          <span class="send-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
-              <path
-                d="M3.4 20.6 22 12 3.4 3.4l-.8 6.2L14 12 2.6 14.4l.8 6.2z"
-              />
-            </svg>
-          </span>
-          <span class="send-label">Send</span>
-        </button>
-      </div>
+      <footer>
+        <p>Cloudflare Workers AI Chat Template &copy; 2025</p>
+      </footer>
     </div>
-
-    <footer>
-      <p>Cloudflare Workers AI Chat Template &copy; 2025</p>
-    </footer>
 
     <!-- Chat app script -->
     <script src="chat.js"></script>


### PR DESCRIPTION
### Motivation
- Update the chat frontend to feel fresher and more modern with an improved color palette, spacing, and elevated surfaces.
- Improve accessibility and UX by refining input focus styles, button affordances, and readable typography.
- Verify there are no immediate production vulnerabilities before shipping the visual refresh.

### Description
- Reworked `public/index.html` CSS variables to introduce a new palette, accent color, surface/shadow tokens, and ring color.
- Replaced the page layout with a centered `.page` wrapper and a card-like `header` and `.chat-container` including rounded corners and drop shadows.
- Enhanced message and input styling with larger radii, subtle shadows, focused input ring, and updated button gradient and hover/active shadows.
- Added a header subtitle and tagline badge to better frame the experience and adjusted background to include soft radial gradients.

### Testing
- Ran `npm audit --production` which completed successfully and reported `0 vulnerabilities`.
- Started a local static server and used Playwright to load the page and capture a screenshot which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698622260f80832b8bba6c29f935069d)