### PR TITLE
Add wave background to main page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,8 @@
         color: var(--text-color);
         min-height: 100vh;
         background:
+          url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1440 320' preserveAspectRatio='none'%3E%3Cpath fill='%236d28d9' fill-opacity='0.12' d='M0,160L60,170.7C120,181,240,203,360,186.7C480,171,600,117,720,112C840,107,960,149,1080,176C1200,203,1320,213,1380,218.7L1440,224L1440,320L1380,320C1320,320,1200,320,1080,320C960,320,840,320,720,320C600,320,480,320,360,320C240,320,120,320,60,320L0,320Z'/%3E%3C/svg%3E")
+            bottom center / 100% 240px no-repeat,
           radial-gradient(circle at top left, rgba(109, 40, 217, 0.12), transparent 45%),
           radial-gradient(circle at top right, rgba(34, 211, 238, 0.18), transparent 40%),
           #f8fafc;


### PR DESCRIPTION
### Motivation
- Add a subtle wave graphic behind the UI to increase visual depth and improve the page's visual design.

### Description
- Inserted an inline SVG wave (data URL) into the `body` CSS `background` stack in `public/index.html`, positioned `bottom center` with `100% 240px` sizing and `no-repeat` so it layers beneath existing radial gradients.

### Testing
- Served the `public` directory with `python -m http.server` and captured a full-page screenshot using Playwright which rendered the wave background successfully (artifact: `browser:/tmp/codex_browser_invocations/5cc079d7d1e348c4/artifacts/artifacts/wave-background.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698641a1ae58832ba4783a64a80522eb)