### PR TITLE
Add tech-debt-agent skill with audit script and prioritization guide

### DIFF
--- a/TECH_DEBT_REPORT.md
+++ b/TECH_DEBT_REPORT.md
@@ -1,0 +1,26 @@
+# Technical Debt Report
+
+Generated: 2026-04-10 16:25:46Z
+
+## Metrics
+
+| Signal | Count | Notes |
+|---|---:|---|
+| TODO/FIXME/HACK/XXX markers | 0 | Potential unfinished work or deferred cleanup |
+| TypeScript 'any' usages in src/*.ts | 1 | Potential type-safety erosion |
+| console logging statements | 8 | Potential noisy logs / inconsistent observability |
+| ts-ignore / ts-expect-error | 0 | Type errors intentionally bypassed |
+| Test files (src/*.test.ts) | 1 | Proxy for direct test coverage footprint |
+| TypeScript source files (src/*.ts) | 3 | Codebase size proxy |
+
+## Initial Findings
+
+1. Review all type-safety bypasses and reduce any and ignore directives where practical.
+2. Standardize runtime logging strategy and prune debug-only console output.
+3. Convert deferred TODO/FIXME/HACK/XXX items into tracked backlog issues with owners.
+
+## Suggested Next Actions
+
+- Prioritize high-impact, low-effort fixes first (e.g., remove stale TODOs, replace obvious any annotations).
+- Add or tighten tests around files touched by remediation work.
+- Re-run this audit after each debt-reduction PR to track trend direction.

--- a/skills/tech-debt-agent/SKILL.md
+++ b/skills/tech-debt-agent/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: tech-debt-agent
+description: Identify, prioritize, and reduce technical debt in a software repository. Use when asked to create a tech debt audit, produce a remediation backlog, assess maintainability risks, or convert debt findings into concrete implementation tasks.
+---
+
+# Tech Debt Agent
+
+## Overview
+
+Run a lightweight, repeatable debt audit and convert findings into a prioritized action plan. Focus on measurable signals first, then propose low-risk remediation steps.
+
+## Workflow
+
+1. **Collect signals**
+   - Run `scripts/audit_tech_debt.sh` from this skill against the target repo.
+   - Capture output in a markdown report file in the repo root.
+2. **Classify debt**
+   - Group findings into reliability, testability, maintainability, and security/operations.
+   - Mark each finding with severity (`high`, `medium`, `low`) and effort (`S`, `M`, `L`).
+3. **Prioritize actions**
+   - Recommend a top-5 backlog using impact × effort.
+   - Include at least one quick win that can be done in <1 day.
+4. **Apply one improvement now**
+   - Implement one small, safe remediation item when requested.
+   - Re-run relevant checks/tests.
+
+## Severity rubric
+
+- **High**: likely production impact, regressions, or blocked velocity.
+- **Medium**: recurring developer friction or increased defect probability.
+- **Low**: style/cleanup work with minor immediate impact.
+
+## Output contract
+
+Produce:
+- A `TECH_DEBT_REPORT.md` file with metrics and findings.
+- A prioritized backlog table with owner suggestions and validation checks.
+
+## Resources
+
+### scripts/
+- `audit_tech_debt.sh`: repository scanner that outputs markdown debt metrics.
+
+### references/
+- `prioritization-matrix.md`: impact/effort scoring and backlog template.

--- a/skills/tech-debt-agent/agents/openai.yaml
+++ b/skills/tech-debt-agent/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Tech Debt Agent
+short_description: Find and reduce technical debt safely.
+default_prompt: Analyze this repository for technical debt and output a prioritized remediation plan with concrete next steps and validation checks.

--- a/skills/tech-debt-agent/references/prioritization-matrix.md
+++ b/skills/tech-debt-agent/references/prioritization-matrix.md
@@ -1,0 +1,21 @@
+# Tech Debt Prioritization Matrix
+
+## Scoring
+
+- **Impact (1-5):** Production risk reduction, developer velocity gain, defect prevention.
+- **Effort (1-5):** Engineering time, coordination complexity, migration risk.
+- **Priority score:** `impact / effort` (higher first).
+
+## Backlog template
+
+| Item | Category | Impact | Effort | Priority | Owner | Validation |
+|---|---|---:|---:|---:|---|---|
+| Replace broad `any` type in request parser | Maintainability | 4 | 2 | 2.0 | Backend | Typecheck + tests |
+| Remove obsolete TODO in handler | Maintainability | 2 | 1 | 2.0 | Backend | Code review |
+| Add test for edge-case payload limit | Reliability | 5 | 2 | 2.5 | QA/Backend | Test passes |
+
+## SLA suggestion
+
+- **High debt:** resolve within 1 sprint.
+- **Medium debt:** schedule within 1-2 quarters.
+- **Low debt:** bundle with nearby feature work.

--- a/skills/tech-debt-agent/scripts/audit_tech_debt.sh
+++ b/skills/tech-debt-agent/scripts/audit_tech_debt.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-.}"
+OUT_FILE="${2:-$REPO_ROOT/TECH_DEBT_REPORT.md}"
+
+cd "$REPO_ROOT"
+
+count_matches() {
+  local cmd="$1"
+  bash -lc "$cmd" 2>/dev/null | wc -l | tr -d ' '
+}
+
+TODO_COUNT=$(count_matches "rg -n 'TODO|FIXME|HACK|XXX' src public --glob '!**/*.min.*' || true")
+ANY_COUNT=$(count_matches "rg -n '\\bany\\b' src --glob '*.ts' || true")
+CONSOLE_COUNT=$(count_matches "rg -n 'console\\.(log|error|warn|debug)' src public || true")
+TS_IGNORE_COUNT=$(count_matches "rg -n '@ts-ignore|@ts-expect-error' src || true")
+
+TEST_FILES=$(count_matches "rg --files src | rg '\\.test\\.ts$' || true")
+SOURCE_FILES=$(count_matches "rg --files src | rg '\\.ts$' || true")
+
+{
+  echo "# Technical Debt Report"
+  echo
+  echo "Generated: $(date -u +'%Y-%m-%d %H:%M:%SZ')"
+  echo
+  echo "## Metrics"
+  echo
+  echo "| Signal | Count | Notes |"
+  echo "|---|---:|---|"
+  echo "| TODO/FIXME/HACK/XXX markers | $TODO_COUNT | Potential unfinished work or deferred cleanup |"
+  echo "| TypeScript 'any' usages in src/*.ts | $ANY_COUNT | Potential type-safety erosion |"
+  echo "| console logging statements | $CONSOLE_COUNT | Potential noisy logs / inconsistent observability |"
+  echo "| ts-ignore / ts-expect-error | $TS_IGNORE_COUNT | Type errors intentionally bypassed |"
+  echo "| Test files (src/*.test.ts) | $TEST_FILES | Proxy for direct test coverage footprint |"
+  echo "| TypeScript source files (src/*.ts) | $SOURCE_FILES | Codebase size proxy |"
+  echo
+  echo "## Initial Findings"
+  echo
+  echo "1. Review all type-safety bypasses and reduce any and ignore directives where practical."
+  echo "2. Standardize runtime logging strategy and prune debug-only console output."
+  echo "3. Convert deferred TODO/FIXME/HACK/XXX items into tracked backlog issues with owners."
+  echo
+  echo "## Suggested Next Actions"
+  echo
+  echo "- Prioritize high-impact, low-effort fixes first (e.g., remove stale TODOs, replace obvious any annotations)."
+  echo "- Add or tighten tests around files touched by remediation work."
+  echo "- Re-run this audit after each debt-reduction PR to track trend direction."
+} > "$OUT_FILE"
+
+echo "Wrote $OUT_FILE"


### PR DESCRIPTION
### Motivation

- Provide a repeatable, local agent (skill) to detect and convert technical debt signals into an actionable remediation plan.  
- Enable quick, measurable audits that produce a `TECH_DEBT_REPORT.md` and a prioritized backlog template.  
- Surface a simple agent interface so the skill can be invoked programmatically with a clear default prompt and metadata.

### Description

- Added a new skill folder `skills/tech-debt-agent` containing `SKILL.md` with trigger description, workflow, severity rubric, and output contract.  
- Added `agents/openai.yaml` with `display_name`, `short_description`, and `default_prompt` to describe the agent UI surface.  
- Added an executable audit script `scripts/audit_tech_debt.sh` that scans the repository for signals (`TODO|FIXME|HACK|XXX` markers, `any` usages, `console.*` statements, `@ts-ignore/@ts-expect-error`, and counts test/source files) and writes a markdown report to `TECH_DEBT_REPORT.md`; the script includes defensive handling for no-match cases.  
- Added `references/prioritization-matrix.md` with an impact/effort scoring scheme and a backlog template to prioritize remediation items.  
- Produced an initial `TECH_DEBT_REPORT.md` by running the audit script against the repository root.

### Testing

- Ran the audit script with `skills/tech-debt-agent/scripts/audit_tech_debt.sh /workspace/daddy-dig /workspace/daddy-dig/TECH_DEBT_REPORT.md`, which completed successfully and wrote `TECH_DEBT_REPORT.md`.  
- Fixed shell escaping issues (reported `any: command not found`) and re-ran the audit to verify correct output.  
- Attempted to validate the skill using `scripts/generate_openai_yaml.py` and `scripts/quick_validate.py`, but both failed due to missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`), so automatic YAML-based validation was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d923d7452c832ba48efaa07fb6adac)